### PR TITLE
EXCLUDE_ALL_MODULES fix

### DIFF
--- a/src/main/shell/utils/script/operational_utils_dcos_deploy_service.sh
+++ b/src/main/shell/utils/script/operational_utils_dcos_deploy_service.sh
@@ -167,7 +167,7 @@ do
 	${DEBUG} && echo "CURRENT_MODULE_EXCLUDED=${CURRENT_MODULE_EXCLUDED}"
 	# If the module should be deployed.
 	if ( [ ${INCLUDE_MODULES_EMPTY} = "0" ] || [ "${INCLUDE_ALL_MODULES}" = "0" ] || [ "${CURRENT_MODULE_INCLUDED}" = "0" ] ) && \
-		( [ ${EXCLUDE_MODULES_EMPTY} = "0" ] || [ "${EXCLUDE_ALL_MODULES}" != "0" ] || [ "${CURRENT_MODULE_EXCLUDED}" != "0" ] )
+		( [ ${EXCLUDE_MODULES_EMPTY} = "0" ] || [ "${EXCLUDE_ALL_MODULES}" = "0" ] || [ "${CURRENT_MODULE_EXCLUDED}" != "0" ] )
 	then
 	
 		# Goes to the module directory.

--- a/src/main/shell/utils/script/operational_utils_docker_build_modules.sh
+++ b/src/main/shell/utils/script/operational_utils_docker_build_modules.sh
@@ -144,7 +144,7 @@ do
 	${DEBUG} && echo "CURRENT_MODULE_EXCLUDED=${CURRENT_MODULE_EXCLUDED}"
 	# If the module should be built.
 	if ( [ ${INCLUDE_MODULES_EMPTY} = "0" ] || [ "${INCLUDE_ALL_MODULES}" = "0" ] || [ "${CURRENT_MODULE_INCLUDED}" = "0" ] ) && \
-		( [ ${EXCLUDE_MODULES_EMPTY} = "0" ] || [ "${EXCLUDE_ALL_MODULES}" != "0" ] || [ "${CURRENT_MODULE_EXCLUDED}" != "0" ] )
+		( [ ${EXCLUDE_MODULES_EMPTY} = "0" ] || [ "${EXCLUDE_ALL_MODULES}" = "0" ] || [ "${CURRENT_MODULE_EXCLUDED}" != "0" ] )
 	then
 
 		# If there is a service config.


### PR DESCRIPTION
the statement
```
 [ "${EXCLUDE_ALL_MODULES}" != "0" ] 
```
in 
```
if ( [ ${INCLUDE_MODULES_EMPTY} = "0" ] || [ "${INCLUDE_ALL_MODULES}" = "0" ] || [ "${CURRENT_MODULE_INCLUDED}" = "0" ] ) && \
    ( [ ${EXCLUDE_MODULES_EMPTY} = "0" ] || [ "${EXCLUDE_ALL_MODULES}" != "0" ] || [ "${CURRENT_MODULE_EXCLUDED}" != "0" ] )
then
```
 is always **_true_** because
```
[ "${EXCLUDE_MODULES}" = "*" ]
EXCLUDE_ALL_MODULES=$?
```
where `EXCLUDE_ALL_MODULES` is equal `0` when `EXCLUDE_MODULES` is different than `*`

That makes the pipeline always build/deploy all modules.

### Test 01 
![exclude_all_test1](https://user-images.githubusercontent.com/52011888/158600320-e5a72d0c-d093-4948-bf3a-aa962ce35dc6.png)

### Test 02
![exclude_all_test2](https://user-images.githubusercontent.com/52011888/158600311-b6b4c870-697f-4551-aa71-6bb8dba202dd.png)